### PR TITLE
Do not go to rest after job.

### DIFF
--- a/laser/main.cpp
+++ b/laser/main.cpp
@@ -210,7 +210,6 @@ void main_nodisplay() {
     // done
     printf("DONE!...\n");
 	while (!mot->ready() );
-    mot->moveTo(cfg->xrest, cfg->yrest, cfg->zrest);
   }
 }
 


### PR DESCRIPTION
For the requested VisiCut feature (https://github.com/t-oster/VisiCut/issues/176), I need the LAOS to not go to the rest position after finishing a job.
I could add a "move-to 0,0" at the end of a job in software, if I wanted it, so I don't think removing that will cause any harm.
The only difference is, that the "rest-position" in the configfile won't have any use anymore.
What do you think? Do you need the hardware-rest feature?
