### PR TITLE
Fix build error due to duplicate symbols from SD and FAT library

### DIFF
--- a/laser/mbed.patch
+++ b/laser/mbed.patch
@@ -278,7 +278,7 @@ diff -urN mbed.clean/workspace_tools/tests.py mbed/workspace_tools/tests.py
 +    {
 +        "id": "laser", "description": "LaosLaser",
 +        "source_dir": join(TEST_DIR, "net", "protocols", "laser"),
-+        "dependencies": [MBED_LIBRARIES, RTOS_LIBRARIES, ETH_LIBRARY,  SD_FS, FAT_FS],
++        "dependencies": [MBED_LIBRARIES, RTOS_LIBRARIES, ETH_LIBRARY], #,  SD_FS, FAT_FS],
 +    },
  
      # u-blox tests


### PR DESCRIPTION
Trying to build the firmware but it's complaining about duplicate symbols for the SD and FAT library. Looks like the libraries are now included in the firmware repository and shouldn't be included from the mbed repository?
