### PR TITLE
Option to disable runtime cancel button checking.

### DIFF
--- a/laser/LaosMenu/LaosMenu.cpp
+++ b/laser/LaosMenu/LaosMenu.cpp
@@ -527,10 +527,13 @@ void LaosMenu::Handle() {
                                 #endif
                             while ((!feof(runfile)) && mot->ready()) {
                                 mot->write(readint(runfile));
-                                if(dsp->read_nb() == K_CANCEL) {
-                                   while (mot->queue());
-                                   mot->reset();
-                                   fseek(runfile, 0, SEEK_END);
+                                if(cfg->disablecancelcheck == false)
+                                {
+                                    if(dsp->read_nb() == K_CANCEL) {
+                                       while (mot->queue());
+                                       mot->reset();
+                                       fseek(runfile, 0, SEEK_END);
+                                    }
                                 }
                             }
                             #ifdef READ_FILE_DEBUG

--- a/laser/global.cpp
+++ b/laser/global.cpp
@@ -76,6 +76,7 @@ GlobalConfig::GlobalConfig(const std::string& filename)
     cfg.Value("sys.nodisplay", &nodisplay, 1);
     cfg.Value("sys.i2cbaud", &i2cbaud, 9600);
     cfg.Value("sys.cleandir", &cleandir, 1);
+    cfg.Value("sys.disablecancelcheck", &disablecancelcheck, 0);
     
     // Laser
     cfg.Value("laser.enable", &lenable, 1); // laser enable polarity [0/1]

--- a/laser/global.h
+++ b/laser/global.h
@@ -46,6 +46,7 @@ public:
   int nodisplay; // there is no display 
   int cleandir; // remove files from SD at startup
   int i2cbaud; // i2cBaudrate
+  int disablecancelcheck; // if the check for cancel button should be disabled while a job is running
   int xmax, ymax, zmax, emax; // max values
   int xmin, ymin, zmin, emin; // min values
   int xpol, ypol, zpol, epol; // polarity for the home switches


### PR DESCRIPTION
Added a config variable that disables runtime checking of the i2c
display, for those of us who have trouble with our lasers freezing
up part way through a job